### PR TITLE
Added support for auto-requiring module/index

### DIFF
--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -37,7 +37,7 @@
         if (err) {
           return callback(err);
         }
-        result = "var " + this.identifier + " = (function(modules) {\n  var exportCache = {};\n  return function require(name) {\n    var module = exportCache[name];\n    var fn;\n    if (module) {\n      return module;\n    } else if (fn = modules[name]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else if (fn = modules[name +\"/index\"]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else {\n      throw 'module \\'' + name + '\\' not found';\n    }\n  }\n})({";
+        result = "var " + this.identifier + " = (function(modules) {\n  var exportCache = {};\n  return function require(name) {\n    var module = exportCache[name];\n    var fn;\n    if (module) {\n      return module;\n    } else if (fn = modules[name] || fn = modules[name +\"/index\"]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else {\n      throw 'module \\'' + name + '\\' not found';\n    }\n  }\n})({";
         index = 0;
         for (name in sources) {
           _ref = sources[name], filename = _ref.filename, source = _ref.source;

--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -22,7 +22,7 @@
   } catch (err) {
 
   }
-  exports.Package = Package = function() {
+  exports.Package = Package = (function() {
     function Package(config) {
       this.identifier = config.identifier || 'require';
       this.paths = config.paths || ['lib'];
@@ -37,7 +37,7 @@
         if (err) {
           return callback(err);
         }
-        result = "var " + this.identifier + " = (function(modules) {\n  var exportCache = {};\n  return function require(name) {\n    var module = exportCache[name];\n    var fn;\n    if (module) {\n      return module;\n    } else if (fn = modules[name]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else {\n      throw 'module \\'' + name + '\\' not found';\n    }\n  }\n})({";
+        result = "var " + this.identifier + " = (function(modules) {\n  var exportCache = {};\n  return function require(name) {\n    var module = exportCache[name];\n    var fn;\n    if (module) {\n      return module;\n    } else if (fn = modules[name]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else if (fn = modules[name +\"/index\"]) {\n      module = { id: name, exports: {} };\n      fn(module.exports, require, module);\n      exportCache[name] = module.exports;\n      return module.exports;\n    } else {\n      throw 'module \\'' + name + '\\' not found';\n    }\n  }\n})({";
         index = 0;
         for (name in sources) {
           _ref = sources[name], filename = _ref.filename, source = _ref.source;
@@ -205,7 +205,7 @@
       });
     };
     return Package;
-  }();
+  })();
   exports.createPackage = function(config) {
     return new Package(config);
   };

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -44,6 +44,11 @@ exports.Package = class Package
               fn(module.exports, require, module);
               exportCache[name] = module.exports;
               return module.exports;
+            } else if (fn = modules[name +"/index"]) {
+              module = { id: name, exports: {} };
+              fn(module.exports, require, module);
+              exportCache[name] = module.exports;
+              return module.exports;
             } else {
               throw 'module \\'' + name + '\\' not found';
             }

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -39,12 +39,7 @@ exports.Package = class Package
             var fn;
             if (module) {
               return module;
-            } else if (fn = modules[name]) {
-              module = { id: name, exports: {} };
-              fn(module.exports, require, module);
-              exportCache[name] = module.exports;
-              return module.exports;
-            } else if (fn = modules[name +"/index"]) {
+            } else if (fn = modules[name] || fn = modules[name +"/index"]) {
               module = { id: name, exports: {} };
               fn(module.exports, require, module);
               exportCache[name] = module.exports;

--- a/test/fixtures/default/foo/buz/index.coffee
+++ b/test/fixtures/default/foo/buz/index.coffee
@@ -1,0 +1,2 @@
+
+exports.buz= "BUZ"

--- a/test/test_stitch.coffee
+++ b/test/test_stitch.coffee
@@ -5,7 +5,7 @@ stitch = require "stitch"
 fixtureRoot  = __dirname + "/fixtures"
 fixtures     = fixtureRoot + "/default"
 altFixtures  = fixtureRoot + "/alternate"
-fixtureCount = 7
+fixtureCount = 8
 
 defaultOptions =
   identifier: "testRequire"
@@ -156,4 +156,14 @@ module.exports =
       test.ok !module.x
       module.x = "foo"
       test.same "foo", testRequire("module").x
+      test.done()
+
+  "look for module index if necessary": (test) ->
+    test.expect 2
+
+    defaultPackage.compile (err, sources) ->
+      test.ok !err
+      eval sources
+      buz= testRequire("foo/buz").buz
+      test.same buz,  "BUZ"
       test.done()


### PR DESCRIPTION
These commits (2 of 'em, sorry) add support for requiring a module's index, if it's not found otherwise. Which aligns more to node's require().

For example, if you have the structure

```
app/
  views/
    test/
      index.coffee
```

Now when you call `require('app/views/test')` it will load the path of  `'app/views/test/index'` instead, since there's no module entry for `'app/views/test'`.

If you did happen have an `'app/views/test.coffee'` file, it wouldn't look for the index.
