### PR TITLE
Fix double-execution of modules required with differing relative paths.

### DIFF
--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -67,7 +67,7 @@ exports.Package = class Package
               } else if (fn = modules[path] || modules[path = expand(path, './index')]) {
                 module = {id: name, exports: {}};
                 try {
-                  cache[name] = module.exports;
+                  cache[path] = cache[name] = module.exports;
                   fn(module.exports, function(name) {
                     return require(name, dirname(path));
                   }, module);


### PR DESCRIPTION
I encountered a bug where two calls to `require` for the same target module, with differing relative paths to that module, resulted in that module's wrapping closure being executed twice. The issue was because cache misses resulted in calling `fn`, even if the module was already in `modules`. This change makes sure the absolute path to any module is always in `cache`.
