### PR TITLE
Support coffeescript dependencies

### DIFF
--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -42,8 +42,10 @@
   }
   exports.Package = Package = (function() {
     function Package(config) {
-      this.compileSources = __bind(this.compileSources, this);;
-      this.compileDependencies = __bind(this.compileDependencies, this);;      var _ref2, _ref3, _ref4, _ref5;
+      this.compileFile = __bind(this.compileFile, this);
+      this.compileSources = __bind(this.compileSources, this);
+      this.compileDependencies = __bind(this.compileDependencies, this);
+      var _ref2, _ref3, _ref4, _ref5;
       this.identifier = (_ref2 = config.identifier) != null ? _ref2 : 'require';
       this.paths = (_ref3 = config.paths) != null ? _ref3 : ['lib'];
       this.dependencies = (_ref4 = config.dependencies) != null ? _ref4 : [];
@@ -62,7 +64,7 @@
       });
     };
     Package.prototype.compileDependencies = function(callback) {
-      return async.map(this.dependencies, fs.readFile, __bind(function(err, dependencySources) {
+      return async.map(this.dependencies, this.compileFile, __bind(function(err, dependencySources) {
         if (err) {
           return callback(err);
         } else {
@@ -172,7 +174,7 @@
       }, this));
     };
     Package.prototype.compileFile = function(path, callback) {
-      var compile, err, extension, mod, mtime, source;
+      var compile, extension, mod, mtime, source;
       extension = extname(path).slice(1);
       if (this.cache && this.compileCache[path] && this.mtimeCache[path] === this.compileCache[path].mtime) {
         return callback(null, this.compileCache[path].source);

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -49,7 +49,7 @@ exports.Package = class Package
       else callback null, parts.join("\n")
 
   compileDependencies: (callback) =>
-    async.map @dependencies, fs.readFile, (err, dependencySources) =>
+    async.map @dependencies, @compileFile, (err, dependencySources) =>
       if err then callback err
       else callback null, dependencySources.join("\n")
 
@@ -176,7 +176,7 @@ exports.Package = class Package
             return callback null, sourcePath.slice base.length
         callback new Error "#{path} isn't in the require path"
 
-  compileFile: (path, callback) ->
+  compileFile: (path, callback) =>
     extension = extname(path).slice(1)
 
     if @cache and @compileCache[path] and @mtimeCache[path] is @compileCache[path].mtime


### PR DESCRIPTION
This pull request changes the `compileDependencies()` function to use `compileFile` instead of `fs.readFile`. This allows for the use of coffeescript files as dependencies (#20).
