### PR TITLE
Windows Support

### DIFF
--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -162,7 +162,7 @@
           }
           for (_i = 0, _len = expandedPaths.length; _i < _len; _i++) {
             expandedPath = expandedPaths[_i];
-            base = expandedPath + "/";
+            base = expandedPath + join('_', '_')[1];
             if (sourcePath.indexOf(base) === 0) {
               return callback(null, sourcePath.slice(base.length));
             }

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -171,7 +171,7 @@ exports.Package = class Package
         return callback err if err
 
         for expandedPath in expandedPaths
-          base = expandedPath + "/"
+          base = expandedPath + join('_', '_')[1]
           if sourcePath.indexOf(base) is 0
             return callback null, sourcePath.slice base.length
         callback new Error "#{path} isn't in the require path"


### PR DESCRIPTION
There is a line in the current source that appends `'/'` to a path, which causes a later comparison to fail on Windows.  I changed the `'/'` to `path.join('_','_')[1]` in order to get the correct directory separator for the platform, though there may be a nicer way to do this.
