### PR TITLE
Windows relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -1,6 +1,6 @@
 (function() {
-  var CoffeeScript, Package, async, compilers, eco, extname, fs, join, normalize, _, _ref;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  var CoffeeScript, Package, async, compilers, eco, extname, fs, join, normalize, _, _ref,
+    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
   _ = require('underscore');
 
@@ -173,7 +173,7 @@
           if (err) return callback(err);
           for (_i = 0, _len = expandedPaths.length; _i < _len; _i++) {
             expandedPath = expandedPaths[_i];
-            base = expandedPath + "/";
+            base = expandedPath + (process.platform.indexOf("win" !== -1) ? "\\" : "/");
             if (sourcePath.indexOf(base) === 0) {
               return callback(null, sourcePath.slice(base.length));
             }

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -49,7 +49,7 @@ exports.Package = class Package
       else callback null, parts.join("\n")
 
   compileDependencies: (callback) =>
-    async.map @dependencies, fs.readFile, (err, dependencySources) =>
+    async.map @dependencies, @compileFile, (err, dependencySources) =>
       if err then callback err
       else callback null, dependencySources.join("\n")
 
@@ -176,7 +176,7 @@ exports.Package = class Package
             return callback null, sourcePath.slice base.length
         callback new Error "#{path} isn't in the require path"
 
-  compileFile: (path, callback) ->
+  compileFile: (path, callback) =>
     extension = extname(path).slice(1)
 
     if @cache and @compileCache[path] and @mtimeCache[path] is @compileCache[path].mtime

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -171,7 +171,7 @@ exports.Package = class Package
         return callback err if err
 
         for expandedPath in expandedPaths
-          base = expandedPath + "/"
+          base = expandedPath + ( if process.platform.indexOf "win" != -1 then "\\" else "/")
           if sourcePath.indexOf(base) is 0
             return callback null, sourcePath.slice base.length
         callback new Error "#{path} isn't in the require path"


### PR DESCRIPTION
Under a windows environment, the relatives paths were glitchy and always returned a file not found (C:\path\to\file.coffee/). Took that fact into consideration and fixed it.
