### PR TITLE
Stitch produces an invalid file if one of the stitched javascript files ...

### DIFF
--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -114,7 +114,7 @@ exports.Package = class Package
       for name, {filename, source} of sources
         result += if index++ is 0 then "" else ", "
         result += JSON.stringify name
-        result += ": function(exports, require, module) {#{source}}"
+        result += ": function(exports, require, module) {#{source}\n}"
 
       result += """
         });\n


### PR DESCRIPTION
...ends with a line comment without newline eg.

//This is the last line

This is a very simple fix which seems to solve the problem.
