### PR TITLE
Serve from Windows with normal '/'s in your require paths

### DIFF
--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -1,6 +1,6 @@
 (function() {
-  var CoffeeScript, Package, async, compilers, eco, extname, fs, join, normalize, _, _ref;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  var CoffeeScript, Package, async, compilers, eco, extname, fs, join, normalize, _, _ref,
+    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
   _ = require('underscore');
 

--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -173,9 +173,9 @@
           if (err) return callback(err);
           for (_i = 0, _len = expandedPaths.length; _i < _len; _i++) {
             expandedPath = expandedPaths[_i];
-            base = expandedPath + "/";
+            base = normalize(expandedPath + "/");
             if (sourcePath.indexOf(base) === 0) {
-              return callback(null, sourcePath.slice(base.length));
+              return callback(null, sourcePath.slice(base.length).replace(/\\/g, '/'));
             }
           }
           return callback(new Error("" + path + " isn't in the require path"));

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -171,9 +171,9 @@ exports.Package = class Package
         return callback err if err
 
         for expandedPath in expandedPaths
-          base = expandedPath + "/"
+          base = normalize expandedPath + "/"
           if sourcePath.indexOf(base) is 0
-            return callback null, sourcePath.slice base.length
+            return callback null, sourcePath.slice(base.length).replace(/\\/g, '/')
         callback new Error "#{path} isn't in the require path"
 
   compileFile: (path, callback) ->

--- a/test/test_stitch.coffee
+++ b/test/test_stitch.coffee
@@ -299,12 +299,17 @@ module.exports =
       test.done()
 
   "paths may be symlinks": (test) ->
-    test.expect 2
-    linkPackage.compile (err, sources) ->
-      test.ok !err
-      testRequire = load sources
-      test.ok testRequire("foo/bar/baz")
+    if process.platform == 'win32'
+      test.expect 1
+      test.ok true, "Windows doesn't have symlinks"
       test.done()
+    else
+      test.expect 2
+      linkPackage.compile (err, sources) ->
+        test.ok !err
+        testRequire = load sources
+        test.ok testRequire("foo/bar/baz")
+        test.done()
 
 if stitch.compilers.eco
   module.exports["eco compiler"] = (test) ->


### PR DESCRIPTION
This not only fixes the raw '/' in getRelativePath, but also replaces the backslashes you get from Windows with forward slashes when generating the filename key for the compiled module function.

This lets you serve your files from Windows, but still use '/' in your require calls. Using '/' on the client side is nice because it's symmetrical with the server side (node accepts '/' in require on Windows) and lets you serve your files from Windows _and_ Posix. Pus '/' is the One True Path Separator. 

All tests pass (on Windows and Posix), but I cheated on "paths may be symlinks" since Windows doesn't really support symlinks.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sstephenson/stitch/34)

<!-- Reviewable:end -->
