### PR TITLE
Update src/stitch.coffee

### DIFF
--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -171,9 +171,8 @@ exports.Package = class Package
         return callback err if err
 
         for expandedPath in expandedPaths
-          base = expandedPath + "/"
-          if sourcePath.indexOf(base) is 0
-            return callback null, sourcePath.slice base.length
+          if sourcePath.indexOf(expandedPath) is 0
+            return callback null, sourcePath.slice expandedPath.length
         callback new Error "#{path} isn't in the require path"
 
   compileFile: (path, callback) ->


### PR DESCRIPTION
I had trouble getting stitch to work on windows and tracked it down to this line; for one on windows machines the actual path has "\" instead of "/" so this always fails. If I just skip this check it seems to work on both windows and linux systems. I tested with nested folders and everything else I could think of. Since this is literally the only thing preventing windows users from using this, can we remove this check or am I missing an use-case?
