### PR TITLE
Windows separator fix

### DIFF
--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -48,7 +48,9 @@
 
   }
   
-  var sep = (process.platform === 'win32' ? '\\' : '/');
+  var isWindows = process.platform === 'win32';
+  
+  var sep = isWindows ? '\\' : '/';
 
   exports.Package = Package = (function() {
 
@@ -96,7 +98,7 @@
         for (name in sources) {
           _ref2 = sources[name], filename = _ref2.filename, source = _ref2.source;
           result += index++ === 0 ? "" : ", ";
-          result += JSON.stringify(name);
+          result += isWindows ? JSON.stringify(name.replace(/\\/g, '/')) : name;
           result += ": function(exports, require, module) {" + source + "}";
         }
         result += "});\n";

--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -47,10 +47,8 @@
   } catch (err) {
 
   }
-  
-  var isWindows = process.platform === 'win32';
-  
-  var sep = isWindows ? '\\' : '/';
+
+  sep = process.platform === 'win32' ? '\\' : '/';
 
   exports.Package = Package = (function() {
 
@@ -59,7 +57,7 @@
       this.compileDependencies = __bind(this.compileDependencies, this);
       var _ref2, _ref3, _ref4, _ref5;
       this.identifier = (_ref2 = config.identifier) != null ? _ref2 : 'require';
-      this.paths = (_ref3 = config.paths) != null ? _ref3 : ['lib'];
+      this.paths = (_ref3 = config.paths.map(normalize)) != null ? _ref3 : ['lib'];
       this.dependencies = (_ref4 = config.dependencies) != null ? _ref4 : [];
       this.compilers = _.extend({}, compilers, config.compilers);
       this.cache = (_ref5 = config.cache) != null ? _ref5 : true;
@@ -93,12 +91,12 @@
       return async.reduce(this.paths, {}, _.bind(this.gatherSourcesFromPath, this), function(err, sources) {
         var filename, index, name, result, source, _ref2;
         if (err) return callback(err);
-        result = "(function(/*! Stitch !*/) {\n  if (!this." + _this.identifier + ") {\n    var modules = {}, cache = {}, require = function(name, root) {\n      var path = expand(root, name), module = cache[path], fn;\n      if (module) {\n        return module.exports;\n      } else if (fn = modules[path] || modules[path = expand(path, './index')]) {\n        module = {id: path, exports: {}};\n        try {\n          cache[path] = module;\n          fn(module.exports, function(name) {\n            return require(name, dirname(path));\n          }, module);\n          return module.exports;\n        } catch (err) {\n          delete cache[path];\n          throw err;\n        }\n      } else {\n        throw 'module \\'' + name + '\\' not found';\n      }\n    }, expand = function(root, name) {\n      var results = [], parts, part;\n      if (/^\\.\\.?(\\/|$)/.test(name)) {\n        parts = [root, name].join('/').split('/');\n      } else {\n        parts = name.split('/');\n      }\n      for (var i = 0, length = parts.length; i < length; i++) {\n        part = parts[i];\n        if (part == '..') {\n          results.pop();\n        } else if (part != '.' && part != '') {\n          results.push(part);\n        }\n      }\n      return results.join('/');\n    }, dirname = function(path) {\n      return path.split('/').slice(0, -1).join('/');\n    };\n    this." + _this.identifier + " = function(name) {\n      return require(name, '');\n    }\n    this." + _this.identifier + ".define = function(bundle) {\n      for (var key in bundle)\n        modules[key] = bundle[key];\n    };\n  }\n  return this." + _this.identifier + ".define;\n}).call(this)({";
+        result = "(function(/*! Stitch !*/) {\n  if (!this." + _this.identifier + ") {\n    var modules = {}, cache = {}, require = function(name, root) {\n      name = name.replace(/\\\\/g, '/');\n      var path = expand(root, name), module = cache[path], fn;\n      if (module) {\n        return module.exports;\n      } else if (fn = modules[path] || modules[path = expand(path, './index')]) {\n        module = {id: path, exports: {}};\n        try {\n          cache[path] = module;\n          fn(module.exports, function(name) {\n            return require(name, dirname(path));\n          }, module);\n          return module.exports;\n        } catch (err) {\n          delete cache[path];\n          throw err;\n        }\n      } else {\n        throw 'module \\'' + name + '\\' not found';\n      }\n    }, expand = function(root, name) {\n      var results = [], parts, part;\n      if (/^\\.\\.?(\\/|$)/.test(name)) {\n        parts = [root, name].join('/').split('/');\n      } else {\n        parts = name.split('/');\n      }\n      for (var i = 0, length = parts.length; i < length; i++) {\n        part = parts[i];\n        if (part == '..') {\n          results.pop();\n        } else if (part != '.' && part != '') {\n          results.push(part);\n        }\n      }\n      return results.join('/');\n    }, dirname = function(path) {\n      return path.split('/').slice(0, -1).join('/');\n    };\n    this." + _this.identifier + " = function(name) {\n      return require(name, '');\n    }\n    this." + _this.identifier + ".define = function(bundle) {\n      for (var key in bundle)\n        modules[key] = bundle[key];\n    };\n  }\n  return this." + _this.identifier + ".define;\n}).call(this)({";
         index = 0;
         for (name in sources) {
           _ref2 = sources[name], filename = _ref2.filename, source = _ref2.source;
           result += index++ === 0 ? "" : ", ";
-          result += isWindows ? JSON.stringify(name.replace(/\\/g, '/')) : name;
+          result += JSON.stringify(name);
           result += ": function(exports, require, module) {" + source + "}";
         }
         result += "});\n";
@@ -154,7 +152,7 @@
               return callback(err);
             } else {
               extension = extname(relativePath);
-              key = relativePath.slice(0, -extension.length);
+              key = relativePath.slice(0, -extension.length).replace(/\\/g, '/');
               sources[key] = {
                 filename: relativePath,
                 source: source

--- a/lib/stitch.js
+++ b/lib/stitch.js
@@ -47,6 +47,8 @@
   } catch (err) {
 
   }
+  
+  var sep = (process.platform === 'win32' ? '\\' : '/');
 
   exports.Package = Package = (function() {
 
@@ -173,7 +175,7 @@
           if (err) return callback(err);
           for (_i = 0, _len = expandedPaths.length; _i < _len; _i++) {
             expandedPath = expandedPaths[_i];
-            base = expandedPath + "/";
+            base = expandedPath + sep;
             if (sourcePath.indexOf(base) === 0) {
               return callback(null, sourcePath.slice(base.length));
             }

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -28,6 +28,8 @@ try
       module._compile content, filename
 catch err
 
+sep = if process.platform == 'win32' then '\\' else '/'
+
 
 exports.Package = class Package
   constructor: (config) ->
@@ -171,7 +173,7 @@ exports.Package = class Package
         return callback err if err
 
         for expandedPath in expandedPaths
-          base = expandedPath + "/"
+          base = expandedPath + sep
           if sourcePath.indexOf(base) is 0
             return callback null, sourcePath.slice base.length
         callback new Error "#{path} isn't in the require path"

--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -28,7 +28,8 @@ try
       module._compile content, filename
 catch err
 
-sep = if process.platform == 'win32' then '\\' else '/'
+isWindows = process.platform == 'win32'
+sep = if isWindows then '\\' else '/'
 
 
 exports.Package = class Package
@@ -115,7 +116,7 @@ exports.Package = class Package
       index = 0
       for name, {filename, source} of sources
         result += if index++ is 0 then "" else ", "
-        result += JSON.stringify name
+        result += if isWindows then JSON.stringify(name.replace(/\\/g, '/')) else name
         result += ": function(exports, require, module) {#{source}}"
 
       result += """


### PR DESCRIPTION
Replaced the in-place separator string with a variable that gets set similar to the way Node does it.

When upgrading Node to a version that includes [this commit](https://github.com/joyent/node/commit/4bd54dad33722e93bae5a16f6b274d08944c24cc), the declaration of `sep` can easily be replaced with the following change to [line 5](https://github.com/sstephenson/stitch/blob/master/src/stitch.coffee#L5).

``` coffee
{extname, join, normalize, sep} = require 'path'
```
