### PR TITLE
fixed bug with cache entries being overwritten when 'module' was registered under 'module/index'

### DIFF
--- a/src/stitch.coffee
+++ b/src/stitch.coffee
@@ -61,7 +61,7 @@ exports.Package = class Package
         (function(/*! Stitch !*/) {
           if (!this.#{@identifier}) {
             var modules = {}, cache = {}, require = function(name, root) {
-              var path = expand(root, name), module = cache[path], fn;
+              var path = expand(root, name), module = cache[path] || cache[expand(path, './index')], fn;
               if (module) {
                 return module.exports;
               } else if (fn = modules[path] || modules[path = expand(path, './index')]) {


### PR DESCRIPTION
Let's assume there's a module registered under `"test/index"`

When you call `require( "test" )` stitch checks if it has such module in cache under `"test"` path.
If not it checks, if there's such module defined under `"test"` or `"test/index"` and tries to load it.
In this example, It finds the module under `"test/index"` so it creates cache entry for that path.

When the  same module is required again, it will be not found in cache and whole cache entry is recreated (module function will be invoked again)
